### PR TITLE
Circle 2.0 config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,10 @@
+version: 2
+jobs:
+  build:
+    working_directory: ~/marketo_gem
+    docker:
+      - image: kapost/ruby:2.4.3-node-6.11.5
+    steps:
+      - checkout
+      - run: bundle install
+      - run: bundle exec rake

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,0 @@
-test:
-  override:
-    - bundle exec rake


### PR DESCRIPTION
Circle is sunsetting 1.0 builds and configs effective August 31, 2018. This gets marketo_gem on Circle 2.0